### PR TITLE
Tested input_summary_table.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,5 @@ LazyData: true
 RoxygenNote: 7.1.1
 Suggests: 
     testthat (>= 2.1.0),
-    covr
+    covr,
+    stringi

--- a/tests/testthat/input_summary_row_ui_expected.html
+++ b/tests/testthat/input_summary_row_ui_expected.html
@@ -1,0 +1,39 @@
+<tr class="import_summary_row" title="">
+  <td>
+    <p title="abcd">abcd</p>
+  </td>
+  <td>
+    <p></p>
+  </td>
+  <td>
+    <div class="form-group shiny-input-container">
+      <label class="control-label shiny-label-null" for="abcd_protein"></label>
+      <div>
+        <select id="abcd_protein"></select>
+        <script type="application/json" data-for="abcd_protein" data-nonempty="">{}</script>
+      </div>
+    </div>
+  </td>
+  <td>
+    <div class="form-group shiny-input-container">
+      <label class="control-label shiny-label-null" for="abcd_state"></label>
+      <div>
+        <select id="abcd_state"></select>
+        <script type="application/json" data-for="abcd_state" data-nonempty="">{}</script>
+      </div>
+    </div>
+  </td>
+  <td>
+    <div class="form-group shiny-input-container">
+      <div class="checkbox">
+        <label>
+          <input id="abcd_display" type="checkbox"/>
+          <span></span>
+        </label>
+      </div>
+    </div>
+  </td>
+  <td>
+    <button id="abcd_remove" type="button" class="btn btn-default action-button" title="Removes uploaded file.">Remove</button>
+  </td>
+</tr>

--- a/tests/testthat/test-input_summary_table.R
+++ b/tests/testthat/test-input_summary_table.R
@@ -1,0 +1,33 @@
+library(shiny)
+library(stringi)
+
+test_that("input_summary_row_ui function works", {
+
+    input <- list(
+       "input_id" = "abcd",
+       "file_name" = "abcd",
+       "is_ok" = TRUE
+    )
+
+    output_example <- "input_summary_row_ui_expected.html"
+
+    output_expected <- readChar(output_example, file.info(output_example)$size)
+    output_got <- input_summary_row_ui(input)
+
+    expect_equal(stri_split_lines1(output_got), stri_split_lines1(output_expected))
+})
+
+test_that("input_summary_row_server function works", {
+
+    input <- list(
+       "input_id" = "abcd",
+       "file_name" = "abcd",
+       "is_ok" = TRUE
+    )
+
+    input_settings_rv <- shiny::reactiveValues(
+      "fm" = list(), "obs" = list(), "data" = list(), "seq_max_len" = -Inf
+    )
+    
+    expect_equal(length(input_summary_row_server(input, "", "", input_settings_rv)), 3)
+})


### PR DESCRIPTION
Added tests for functions:

- input_summary_row_ui, and
- input_summary_row_server.

The tests contain the simplest comprehensive checks I could get to work
at the moment, "comprehensive" meaning "covering the greatest possible
part of the code".

These tests check the output HTML code from the first function. They do
not check particular properties of the generated code for now, but they
should cover most of the code in the tested functions. They can be used
as a basis for expanding the checks or making them more specific.

Possibilities include counting observers before and after changing the
number of input files (the observers are already counted in the second
test).

Provided tests generate one warning. The warning is:

> (@test-input_summary_table.R#17) - argument is not an atomic vector;
> coercing

The text of the warning can be previewed by selecting a custom test
reporter in testthat.R. To do that, change:

```R
test_check("iaoreader")
```

to:

```R
test_check("iaoreader", reporter="summary")
```